### PR TITLE
Enable OpenSSL compiling in Linux

### DIFF
--- a/tsk/tsk_config.h.in
+++ b/tsk/tsk_config.h.in
@@ -63,6 +63,9 @@
 /* Define to 1 if you have the <libewf.h> header file. */
 #undef HAVE_LIBEWF_H
 
+/* Define if using openssl */
+#undef HAVE_LIBOPENSSL
+
 /* Define to 1 if you have the `sqlite3' library (-lsqlite3). */
 #undef HAVE_LIBSQLITE3
 


### PR DESCRIPTION
Related to https://github.com/sleuthkit/sleuthkit/issues/2862#issue-1870662492

In order to compile APFS decryption code, the flag `HAVE_LIBOPENSSL` must be defined. However, even after running `./configure` and the output shows the output bellow and the flag is not defined.

```
Building:
   openssl support:                       yes

   afflib support:                        yes
   libewf support:                        yes
   zlib support:                          yes

   libbfio support:                       yes
   libvhdi support:                       yes
   libvmdk support:                       yes
   libvslvm support:                      yes
Features:
   Java/JNI support:                      yes
   Multithreading:                        yes
```

After run `autoheader` command, the flag `HAVE_LIBOPENSSL` came back to `tsk_config.h.in`. So the APFS decryption code was compiled.

PS: Using Ubuntu 22.04.

Btw, Ubuntu 22.04 has OpenSSL 3.0. So in order to avoid deprecated errors in compilation, the configure must be run with:
```
./configure CXXFLAGS="-Wno-error=deprecated-declarations"
```